### PR TITLE
Explicitly specify scene agent num constraint

### DIFF
--- a/examples/run_who_is_the_spy.py
+++ b/examples/run_who_is_the_spy.py
@@ -14,9 +14,6 @@ scene_config = WhoIsTheSpySceneConfig(
                     "key_modality": {"current": "text"},
                     "num_rounds": {"current": 1},
                     "has_blank_slate": {"current": False},
-                    "max_agents_num": {},
-                    "min_agents_num_with_blank": {},
-                    "min_agents_num_without_blank": {}
                 }
             },
             "scene_info_obj": scene_info_obj.model_dump(by_alias=True)

--- a/src/leaf_playground/app/app.py
+++ b/src/leaf_playground/app/app.py
@@ -18,6 +18,8 @@ class SceneFull(TypedDict):
     id: str
     scene_metadata: SceneMetaData
     role_agents_num: Dict[str, int]
+    max_agents_num: int
+    min_agents_num: int
     scene_class: Type[Scene]
     scene_config_class: Type[SceneConfig]
     scene_info_class: Type[SceneInfo]
@@ -33,6 +35,8 @@ class SceneDetail(BaseModel):
     scene_metadata: SceneMetaData = Field(default=...)
     agents_metadata: Dict[str, SceneAgentMetadata] = Field(default=...)
     role_agents_num: Dict[str, int] = Field(default=...)
+    max_agents_num: int = Field(default=...)
+    min_agents_num: int = Field(default=...)
     scene_info_config_schema: dict = Field(default=...)
     agents_config_schemas: Dict[str, dict] = Field(default=...)
     additional_config_schema: dict = Field(default=...)
@@ -95,6 +99,8 @@ def get_scenes() -> Dict[str, SceneFull]:
             id=scene_id,
             scene_metadata=scene_metadata,
             role_agents_num=scene_metadata.get_roles_agent_num(),
+            max_agents_num=scene_metadata.get_max_dynamic_agents_num(),
+            min_agents_num=scene_metadata.get_min_dynamic_agents_num(),
             scene_class=scene_class,
             scene_config_class=scene_config_class,
             scene_info_class=scene_info_class,
@@ -138,6 +144,8 @@ async def get_scene(scene_id: str) -> SceneDetail:
         scene_metadata=scene_full["scene_metadata"],
         agents_metadata=scene_full["agents_metadata"],
         role_agents_num=scene_full["role_agents_num"],
+        max_agents_num=scene_full["max_agents_num"],
+        min_agents_num=scene_full["min_agents_num"],
         scene_info_config_schema=scene_full["scene_info_config_class"].get_json_schema(by_alias=True),
         agents_config_schemas={
             agent_id: agent_config_class.get_json_schema(by_alias=True) for agent_id, agent_config_class in

--- a/src/leaf_playground/core/scene_info.py
+++ b/src/leaf_playground/core/scene_info.py
@@ -134,6 +134,24 @@ class SceneMetaData(Data):
             role.name: role.num_agents for role in self.role_definitions
         }
 
+    def get_max_dynamic_agents_num(self) -> int:
+        num = 0
+        for role_def in self.role_definitions:
+            if role_def.is_static:
+                continue
+            if role_def.num_agents == -1:
+                return -1
+            num += role_def.num_agents
+        return num
+
+    def get_min_dynamic_agents_num(self) -> int:
+        num = 0
+        for role_def in self.role_definitions:
+            if role_def.is_static:
+                continue
+            num += role_def.num_agents if role_def.num_agents != -1 else 1
+        return num
+
 
 class SceneInfoConfigBase(_Config):
     name: str = Field(default=..., exclude=True)

--- a/src/leaf_playground/zoo/who_is_the_spy/scene_info.py
+++ b/src/leaf_playground/zoo/who_is_the_spy/scene_info.py
@@ -41,21 +41,15 @@ class HasBlankSlateEnvVar(ConstantEnvironmentVariable):
     current_value: bool = Field(default=False)
 
 
-# TODO: how to let the frontend know the default value of the env vars below?
+class WhoIsTheSpySceneMetaData(SceneMetaData):
+    def get_max_dynamic_agents_num(self) -> int:
+        return 9
 
-class MaxAgentsNumEnvVar(ConstantEnvironmentVariable):
-    current_value: int = Field(default=9, exclude=True)
-
-
-class MinAgentsNumWithBlankEnvVar(ConstantEnvironmentVariable):
-    current_value: int = Field(default=5, exclude=True)
+    def get_min_dynamic_agents_num(self) -> int:
+        return 4  # when only has 4 players, there is no blank slate
 
 
-class MinAgensNumWithoutBlankEnvVar(ConstantEnvironmentVariable):
-    current_value: int = Field(default=4, exclude=True)
-
-
-who_is_the_spy_scene_metadata = SceneMetaData(
+who_is_the_spy_scene_metadata = WhoIsTheSpySceneMetaData(
     name="WhoIsTheSpy",
     description="A scene that simulates the Who is the Spy game.",
     role_definitions=[
@@ -89,25 +83,6 @@ who_is_the_spy_scene_metadata = SceneMetaData(
             description="whether the game has blank slates",
             type=DynamicObject(obj="HasBlankSlateEnvVar", module="leaf_playground.zoo.who_is_the_spy.scene_info")
         ),
-        EnvVarDefinition(
-            name="max_agents_num",
-            description="the maximum number of agents in the game",
-            type=DynamicObject(obj="MaxAgentsNumEnvVar", module="leaf_playground.zoo.who_is_the_spy.scene_info")
-        ),
-        EnvVarDefinition(
-            name="min_agents_num_with_blank",
-            description="the minimum number of agents in the game when there are blank slats",
-            type=DynamicObject(
-                obj="MinAgentsNumWithBlankEnvVar", module="leaf_playground.zoo.who_is_the_spy.scene_info"
-            )
-        ),
-        EnvVarDefinition(
-            name="min_agents_num_without_blank",
-            description="the minimum number of agents in the game when there are no blank slats",
-            type=DynamicObject(
-                obj="MinAgensNumWithoutBlankEnvVar", module="leaf_playground.zoo.who_is_the_spy.scene_info"
-            )
-        )
     ]
 )
 


### PR DESCRIPTION
## What does this PR do?

This pr allows each scene to explicitly specify the maximum and minimum dynamic agents num