### PR TITLE
Status control

### DIFF
--- a/src/leaf_playground/core/scene.py
+++ b/src/leaf_playground/core/scene.py
@@ -142,7 +142,7 @@ class Scene(_Configurable, ABC, metaclass=SceneMetaClass):
             for agent in agents:
                 agent.bind_env_vars(self.env_vars)
 
-    def wait_agents_ready(self):
+    async def wait_agents_ready(self):
         while True:
             all_agents_ready = True
             for agents in self.agents.values():
@@ -151,7 +151,7 @@ class Scene(_Configurable, ABC, metaclass=SceneMetaClass):
                     all_agents_ready = False
             if all_agents_ready:
                 break
-            time.sleep(0.1)
+            await asyncio.sleep(0.001)
 
     def registry_metric_evaluator(self, evaluator: MetricEvaluator):
         self.evaluators.append(evaluator)

--- a/src/leaf_playground/core/scene_agent.py
+++ b/src/leaf_playground/core/scene_agent.py
@@ -5,9 +5,8 @@ from sys import _getframe
 from typing import Any, Dict, Optional
 
 from pydantic import create_model, BaseModel, Field
-from fastapi import WebSocket, WebSocketDisconnect
+from fastapi import WebSocket
 from fastapi.websockets import WebSocketState
-from websockets.exceptions import ConnectionClosed, ConnectionClosedOK, ConnectionClosedError
 
 from .workers.socket_handler import SocketHandler
 from .scene_definition import RoleDefinition
@@ -34,13 +33,66 @@ class _ActionHandler:
         self.exec_timeout = exec_timeout
 
         self.executable = executable
+        # this will force the same action of one instance be called once in every moment
+        # thus calling the same action of one instance multiple times concurrently
+        # it will still run sequentially
+        self._lock = asyncio.Lock()
+        self._task = None
+        self._clock = None
+        self._executed_seconds = 0.0
+
+    async def _record_executed_seconds(self):
+        interval = 1
+        while True:
+            await asyncio.sleep(interval)
+            self._executed_seconds += interval
+
+    def _reset_clock(self):
+        self._clock: asyncio.Task
+        if self._clock is not None:
+            self._clock.cancel()
+        self._clock = None
+
+    def _reset(self):
+        self._task = None
+        self._reset_clock()
+        self._executed_seconds = 0.0
 
     async def execute(self, *args, **kwargs):
         await self.executable.wait()
         try:
-            return await asyncio.wait_for(self.action_fn(*args, **kwargs), timeout=self.exec_timeout)
-        except asyncio.TimeoutError:
-            raise TimeoutError(f"action [{self.action_name}] execution exceeded the time limit: {self.exec_timeout}s.")
+            async with self._lock:
+                if not self._clock:
+                    self._clock = asyncio.ensure_future(self._record_executed_seconds())
+                self._task = asyncio.ensure_future(
+                    asyncio.wait_for(
+                        self.action_fn(*args, **kwargs),
+                        timeout=self.exec_timeout - self._executed_seconds
+                    )
+                )
+                await self._task
+                res = self._task.result()
+                self._reset()
+            return res
+        except asyncio.CancelledError as e:
+            if not self.executable.is_set():  # cancel will be called when agent is paused
+                self._reset_clock()
+                return await self.execute(*args, **kwargs)
+            else:  # other case, raise cancel error
+                self._reset()
+                raise
+        except asyncio.TimeoutError as e:
+            self._reset()
+            raise TimeoutError(
+                f"action [{self.action_name}] execution exceeded the time limit: {self.exec_timeout}s."
+            )
+        except Exception as e:
+            self._reset()
+            raise
+
+    @property
+    def task(self):
+        return self._task
 
 
 class _HumanActionHandler(_ActionHandler):
@@ -72,6 +124,7 @@ class SceneAgentMetadata(BaseModel):
     config_schema: Optional[dict] = Field(default=...)
     obj_for_import: DynamicObject = Field(default=...)
     is_human: bool = Field(default=...)
+    action_timeout_seconds: int = Field(default=...)
 
 
 class SceneAgentMetaClass(ABCMeta):
@@ -214,6 +267,10 @@ class SceneAgent(_Configurable, ABC, metaclass=SceneAgentMetaClass):
 
     def pause(self):
         self._not_paused.clear()
+        for action_handler in self._action2handler.values():
+            if action_handler.task is not None and not action_handler.task.done():
+                # TODO: can't using cancel in the future if we want to support streaming the action result
+                action_handler.task.cancel()
 
     def resume(self):
         self._not_paused.set()
@@ -257,7 +314,8 @@ class SceneAgent(_Configurable, ABC, metaclass=SceneAgentMetaClass):
             description=cls.cls_description,
             config_schema=cls.config_cls.get_json_schema(by_alias=True) if not cls.role_definition.is_static else None,
             obj_for_import=cls.obj_for_import,
-            is_human=False
+            is_human=False,
+            action_timeout_seconds=cls.action_exec_timeout
         )
 
 
@@ -424,7 +482,6 @@ class SceneHumanAgent(SceneDynamicAgent, ABC):
         self.connection: HumanConnection = None
         self.human_input = None
         self.wait_human_input = False
-        self.timeout_left = self.action_exec_timeout
 
         if ABC not in self.__class__.__bases__:
             for action in self.role_definition.actions:
@@ -454,11 +511,9 @@ class SceneHumanAgent(SceneDynamicAgent, ABC):
         self.connection.notify_human_to_input()
         while not self.human_input:
             await asyncio.sleep(0.1)
-            self.timeout_left -= 0.1
         self.wait_human_input = False
         if self.connected:
             self.connection.notify_human_to_not_input()
-        self.timeout_left = self.action_exec_timeout
         human_input = self.human_input
         self.human_input = None
         return human_input

--- a/src/leaf_playground/core/scene_engine.py
+++ b/src/leaf_playground/core/scene_engine.py
@@ -162,16 +162,8 @@ class SceneEngine:
 
         for evaluator in self.evaluators:
             evaluator.join()
-        self.logger.add_log(
-            SystemLogBody(system_event=SystemEvent.EVALUATION_FINISHED)
-        )
 
-        self.logger.add_log(
-            SystemLogBody(system_event=SystemEvent.EVERYTHING_DONE)
-        )
-
-        self.state = SceneEngineState.FINISHED
-        self.logger.stop()
+        self.stop()
 
     def pause(self):
         if self.state not in [SceneEngineState.FINISHED, SceneEngineState.INTERRUPTED, SceneEngineState.FAILED]:
@@ -189,6 +181,16 @@ class SceneEngine:
             self.scene.interrupt()
             for evaluator in self.evaluators:
                 evaluator.terminate()
+
+    def stop(self):
+        if self.state not in [SceneEngineState.FINISHED, SceneEngineState.INTERRUPTED, SceneEngineState.FAILED]:
+            self.logger.add_log(
+                SystemLogBody(system_event=SystemEvent.EVALUATION_FINISHED)
+            )
+            self.logger.add_log(
+                SystemLogBody(system_event=SystemEvent.EVERYTHING_DONE)
+            )
+            self.state = SceneEngineState.FINISHED
 
     def get_scene_config(
             self,

--- a/src/leaf_playground/core/scene_engine.py
+++ b/src/leaf_playground/core/scene_engine.py
@@ -137,11 +137,11 @@ class SceneEngine:
     def id(self) -> str:
         return self._id
 
-    def _wait_agents_ready(self):
-        self.scene.wait_agents_ready()
+    async def _wait_agents_ready(self):
+        await self.scene.wait_agents_ready()
 
     async def run(self):
-        self._wait_agents_ready()
+        await self._wait_agents_ready()
 
         self.state = SceneEngineState.RUNNING
 

--- a/src/leaf_playground/core/workers/logger.py
+++ b/src/leaf_playground/core/workers/logger.py
@@ -44,20 +44,5 @@ class Logger:
     def logs(self):
         return self._logs
 
-    async def stream_logs(self, log_handler: Callable[[LogBody], Any] = print):
-        cur = 0
-        while not self._stopped:
-            if cur >= len(self.logs):
-                await asyncio.sleep(0.001)
-            else:
-                await run_asynchronously(log_handler, self.logs[cur])
-                await asyncio.sleep(0.001)
-                cur += 1
-        for log in self.logs[cur:]:
-            await run_asynchronously(log_handler, log)
-
-    def stop(self):
-        self._stopped = True
-
 
 __all__ = ["Logger"]

--- a/src/leaf_playground/data/log_body.py
+++ b/src/leaf_playground/data/log_body.py
@@ -54,6 +54,10 @@ class ActionLogBody(LogBody):
 
 class SystemEvent(Enum):
     SIMULATION_START = "simulation_start"
+    SIMULATION_PAUSED = "simulation_paused"
+    SIMULATION_RESUME = "simulation_resume"
+    SIMULATION_FAILED = "simulation_failed"
+    SIMULATION_INTERRUPTED = "simulation_interrupted"
     SIMULATION_FINISHED = "simulation_finished"
     EVALUATION_FINISHED = "evaluation_finished"
     EVERYTHING_DONE = "everything_done"

--- a/src/leaf_playground_cli/main.py
+++ b/src/leaf_playground_cli/main.py
@@ -192,7 +192,7 @@ def publish_project(
     raise typer.Exit()
 
 
-__web_ui_version__ = "v0.2.0"
+__web_ui_version__ = "v0.3.0"
 __web_ui_release_site__ = "https://github.com/LLM-Evaluation-s-Always-Fatiguing/leaf-playground-webui/releases/download"
 __web_ui_download_url__ = __web_ui_release_site__ + f"/{__web_ui_version__}/webui-{__web_ui_version__}.zip"
 __web_ui_hash_url__ = __web_ui_release_site__ + f"/{__web_ui_version__}/webui-{__web_ui_version__}.zip.sha256"


### PR DESCRIPTION
## What does this PR do?

This pr implement engine status controling mechanisms for pausing, resuming and interrupting a created engine(task). More detailed:
1. Pause: using an `asyncio.Event` to block action's execution util its resumed, if the action already started running, cancel it and re-run after resumed.
2. Resume: set the event so that action can be executed.
3. Interrupt: cancel scene's `_run` task and terminate evaluators, kill task web service's process.

Also, when save task results, the task web service's process will also be killed after things are saved.