### PR TITLE
Log Exporter

### DIFF
--- a/src/leaf_playground/core/scene_definition/scene_definition.py
+++ b/src/leaf_playground/core/scene_definition/scene_definition.py
@@ -5,7 +5,7 @@ from pydantic import create_model, BaseModel, Field, PositiveInt, PrivateAttr
 
 from . import MetricDefinition
 from .definitions import EnvVarDefinition, EnvVarConfig, MetricConfig, RoleDefinition, RoleConfig
-from ..workers.logger import LogExporter, _KEPT_LOG_FILE_NAME
+from ..workers.logger import LogExporter, _KeptLogExporter
 from ..._config import _Config
 
 _EnvVarName = str
@@ -19,7 +19,7 @@ class SceneDefinition(BaseModel):
     roles: List[RoleDefinition] = Field(default=...)
 
     _log_exporters: List[LogExporter] = PrivateAttr(
-        default=[LogExporter(file_name=_KEPT_LOG_FILE_NAME, extension=ext) for ext in ["json", "jsonl", "csv"]]
+        default=[_KeptLogExporter(extension=ext) for ext in ["json", "jsonl", "csv"]]
     )
 
     @property

--- a/src/leaf_playground/core/scene_definition/scene_definition.py
+++ b/src/leaf_playground/core/scene_definition/scene_definition.py
@@ -1,10 +1,11 @@
 from sys import _getframe
 from typing import Any, Dict, List, Literal, Optional, Tuple, Type, Union
 
-from pydantic import create_model, BaseModel, Field, PositiveInt
+from pydantic import create_model, BaseModel, Field, PositiveInt, PrivateAttr
 
 from . import MetricDefinition
 from .definitions import EnvVarDefinition, EnvVarConfig, MetricConfig, RoleDefinition, RoleConfig
+from ..workers.logger import LogExporter, _KEPT_LOG_FILE_NAME
 from ..._config import _Config
 
 _EnvVarName = str
@@ -17,9 +18,17 @@ class SceneDefinition(BaseModel):
     env_vars: List[EnvVarDefinition] = Field(default=...)
     roles: List[RoleDefinition] = Field(default=...)
 
+    _log_exporters: List[LogExporter] = PrivateAttr(
+        default=[LogExporter(file_name=_KEPT_LOG_FILE_NAME, extension=ext) for ext in ["json", "jsonl", "csv"]]
+    )
+
     @property
     def roles_agent_num_range(self) -> Dict[str, Tuple[PositiveInt, Union[PositiveInt, Literal[-1]]]]:
         return {role.name: role.num_agents_range for role in self.roles}
+
+    @property
+    def log_exporters(self):
+        return self._log_exporters
 
     def model_post_init(self, __context: Any) -> None:
         if len(set([r.name for r in self.roles])) != len(self.roles):
@@ -44,6 +53,14 @@ class SceneDefinition(BaseModel):
         return (
             self.get_role_definition(role_name).get_action_definition(action_name).get_metric_definition(metric_name)
         )
+
+    def registry_log_exporters(self, log_exporters: List[LogExporter]):
+        name2exporter = {f"{exporter.file_name}.{exporter.extension}": exporter for exporter in self.log_exporters}
+        for exporter in log_exporters:
+            name = f"{exporter.file_name}:{exporter.extension}"
+            name2exporter[name] = exporter
+
+        self._log_exporters = list(name2exporter.values())
 
 
 class SceneEnvVarsConfig(_Config):

--- a/src/leaf_playground/core/scene_engine.py
+++ b/src/leaf_playground/core/scene_engine.py
@@ -209,9 +209,8 @@ class SceneEngine:
         with open(join(self.save_dir, "evaluator_configs.json"), "w", encoding="utf-8") as f:
             json.dump(evaluator_configs, f, indent=4, ensure_ascii=False)
 
-        with open(join(self.save_dir, "logs.jsonl"), "w", encoding="utf-8") as f:
-            for log in self.logger.logs:
-                f.write(json.dumps(log.model_dump(mode="json"), ensure_ascii=False) + "\n")
+        for exporter in self.scene.scene_definition.log_exporters:
+            exporter.export(self.logger, self.save_dir)
 
         metrics_data, charts = self.reporter.generate_reports(
             scene_config=self.get_scene_config(mode="pydantic"),

--- a/src/leaf_playground/core/workers/logger.py
+++ b/src/leaf_playground/core/workers/logger.py
@@ -53,7 +53,7 @@ _KEPT_LOG_FILE_NAME = ".log"
 
 
 class LogExporter(BaseModel):
-    file_name: str = Field(default="logs")
+    file_name: str = Field(default="log")
     extension: Literal["json", "jsonl", "csv"] = Field(default="jsonl")
 
     def model_post_init(self, __context: Any) -> None:
@@ -91,6 +91,13 @@ class LogExporter(BaseModel):
             if os.path.exists(save_path):
                 os.remove(save_path)
             warnings.warn(f"{self.__class__.__name__}.{func_name} export log failed.")
+
+
+class _KeptLogExporter(LogExporter):
+    file_name: str = Field(default=_KEPT_LOG_FILE_NAME)
+
+    def model_post_init(self, __context: Any) -> None:
+        pass
 
 
 __all__ = ["Logger", "LogExporter"]


### PR DESCRIPTION
## What does this PR do?

This pr add `LogExporter` class with default logic to export logs to `json`, `jsonl`, `csv` formats and allow developers to inherit this class to customize their log export logics.